### PR TITLE
Update default fire_emis_factors_file

### DIFF
--- a/bld/namelist_files/namelist_defaults_fire_emis.xml
+++ b/bld/namelist_files/namelist_defaults_fire_emis.xml
@@ -17,6 +17,6 @@ attributes from the config_cache.xml file (with keys converted to upper-case).
 
 <fire_emis_specifier>'bc_a1 = BC','pom_a1 = 1.4*OC','SO2 = SO2'</fire_emis_specifier>
 
-<fire_emis_factors_file>lnd/clm2/firedata/fire_emis_factors_c140116.nc</fire_emis_factors_file>
+<fire_emis_factors_file>lnd/clm2/firedata/fire_emission_factors_78PFTs_c20240624.nc</fire_emis_factors_file>
 
 </namelist_defaults>


### PR DESCRIPTION
As described in ESCOMP/CTSM#2734.

Tested by building namelist in a case with `-fire_emis` included. If you'd like me to run aux_clm or some subset of it, let me know.

One potential issue is that it's going from a 16-PFT file to a 78-PFT one; not sure if that might cause problems with certain compsets/settings.