### PR TITLE
Update hillslope testing fsurdat to 5.3

### DIFF
--- a/cime_config/testdefs/testmods_dirs/clm/Hillslope/user_nl_clm
+++ b/cime_config/testdefs/testmods_dirs/clm/Hillslope/user_nl_clm
@@ -6,6 +6,6 @@ hillslope_transmissivity_method = 'LayerSum'
 hillslope_pft_distribution_method = 'PftLowlandUpland'
 hillslope_soil_profile_method = 'Uniform'
 
-fsurdat = '$DIN_LOC_ROOT/lnd/clm2/testdata/surfdata_10x15_hist_2000_78pfts_c240905.synthetic_hillslopes3.nc'
+fsurdat = '$DIN_LOC_ROOT/lnd/clm2/surfdata_esmf/ctsm5.3.0/synthetic/surfdata_10x15_hist_2000_78pfts_c240905.synthetic_hillslopes3.nc'
 
 use_ssre = .false.

--- a/cime_config/testdefs/testmods_dirs/clm/Hillslope/user_nl_clm
+++ b/cime_config/testdefs/testmods_dirs/clm/Hillslope/user_nl_clm
@@ -6,6 +6,6 @@ hillslope_transmissivity_method = 'LayerSum'
 hillslope_pft_distribution_method = 'PftLowlandUpland'
 hillslope_soil_profile_method = 'Uniform'
 
-fsurdat = '$DIN_LOC_ROOT/lnd/clm2/testdata/surfdata_10x15_hist_2000_78pfts_c240216.synthetic_hillslopes.nc'
+fsurdat = '$DIN_LOC_ROOT/lnd/clm2/testdata/surfdata_10x15_hist_2000_78pfts_c240905.synthetic_hillslopes.nc'
 
 use_ssre = .false.

--- a/cime_config/testdefs/testmods_dirs/clm/Hillslope/user_nl_clm
+++ b/cime_config/testdefs/testmods_dirs/clm/Hillslope/user_nl_clm
@@ -6,6 +6,6 @@ hillslope_transmissivity_method = 'LayerSum'
 hillslope_pft_distribution_method = 'PftLowlandUpland'
 hillslope_soil_profile_method = 'Uniform'
 
-fsurdat = '$DIN_LOC_ROOT/lnd/clm2/testdata/surfdata_10x15_hist_2000_78pfts_c240905.synthetic_hillslopes.nc'
+fsurdat = '$DIN_LOC_ROOT/lnd/clm2/testdata/surfdata_10x15_hist_2000_78pfts_c240905.synthetic_hillslopes2.nc'
 
 use_ssre = .false.

--- a/cime_config/testdefs/testmods_dirs/clm/Hillslope/user_nl_clm
+++ b/cime_config/testdefs/testmods_dirs/clm/Hillslope/user_nl_clm
@@ -6,6 +6,6 @@ hillslope_transmissivity_method = 'LayerSum'
 hillslope_pft_distribution_method = 'PftLowlandUpland'
 hillslope_soil_profile_method = 'Uniform'
 
-fsurdat = '$DIN_LOC_ROOT/lnd/clm2/testdata/surfdata_10x15_hist_2000_78pfts_c240905.synthetic_hillslopes2.nc'
+fsurdat = '$DIN_LOC_ROOT/lnd/clm2/testdata/surfdata_10x15_hist_2000_78pfts_c240905.synthetic_hillslopes3.nc'
 
 use_ssre = .false.


### PR DESCRIPTION
Resolves ESCOMP/CTSM#2748

- [x] `hillslope` test suite, Derecho: Completes successfully
- [x] `rimport`
- [x] `hillslope` test suite, Izumi: Completes successfully