### PR TITLE
Enable li2024crujra fire_method

### DIFF
--- a/bld/namelist_files/namelist_defaults_ctsm.xml
+++ b/bld/namelist_files/namelist_defaults_ctsm.xml
@@ -238,7 +238,7 @@ attributes from the config_cache.xml file (with keys converted to upper-case).
 <melt_non_icesheet_ice_runoff phys="clm4_5" >.false.</melt_non_icesheet_ice_runoff>
 
 <!-- CN Fire model method defaults -->
-<fire_method               >li2021gswpfrc</fire_method>
+<fire_method               >li2024crujra</fire_method>
 <fire_method phys="clm5_0" >li2016crufrc</fire_method>
 <fire_method phys="clm4_5" >li2014qianfrc</fire_method>
 

--- a/cime_config/testdefs/testlist_clm.xml
+++ b/cime_config/testdefs/testlist_clm.xml
@@ -3562,7 +3562,6 @@
 
   <test name="SMS_D_Ld65" grid="f10_f10_mg37" compset="I2000Clm60BgcCrop" testmods="clm/FireLi2024CruJra">
     <machines>
-      <machine name="derecho" compiler="intel" category="aux_clm"/>
       <machine name="derecho" compiler="intel" category="fire"/>
     </machines>
     <options>


### PR DESCRIPTION
Also removes the FireLi2024CruJra test from aux_clm, since it's now the default. Previous default was and is still tested specifically.

Contributes to ESCOMP/CTSM#2500.